### PR TITLE
Modifica funciones para simplificar el código

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,21 +193,11 @@ function ocultarTodosLosCuadros() {
 }
 
 function comprobarCuadroElegido(e) {
-  if (e.target === cuadrosElegidos[0]) {
-    return "Es el mismo cuadro";
-  } else {
-    return "";
-  }
+  return e.target === cuadrosElegidos[0];
 }
 
 function comprobarColoresCuadros() {
-  for (let i = 0; i < cuadrosElegidos[0].classList.length; i++) {
-    if (cuadrosElegidos[0].classList[i] !== cuadrosElegidos[1].classList[i]) {
-      return "Los colores no coinciden";
-    }
-  }
-
-  return "";
+  return cuadrosElegidos[0].className === cuadrosElegidos[1].className;
 }
 
 function guardarColoresEncontrados() {

--- a/modo-facil.js
+++ b/modo-facil.js
@@ -29,11 +29,11 @@ $cuadrosGrillaFacil.forEach(function (cuadro) {
           guardarCuadroElegido(e);
           mostrarCuadroElegido(e);
         } else if (indicadorTurnos === 2) {
-          if (comprobarCuadroElegido(e) === "") {
+          if (!comprobarCuadroElegido(e)) {
             guardarCuadroElegido(e);
             mostrarCuadroElegido(e);
 
-            if (comprobarColoresCuadros() === "") {
+            if (comprobarColoresCuadros()) {
               guardarColoresEncontrados();
               comprobarEstadoJuego();
               actualizarTituloJuegoTerminado();

--- a/modo-intermedio.js
+++ b/modo-intermedio.js
@@ -31,11 +31,11 @@ $cuadrosGrillaIntermedio.forEach(function (cuadro) {
           guardarCuadroElegido(e);
           mostrarCuadroElegido(e);
         } else if (indicadorTurnos === 2) {
-          if (comprobarCuadroElegido(e) === "") {
+          if (!comprobarCuadroElegido(e)) {
             guardarCuadroElegido(e);
             mostrarCuadroElegido(e);
 
-            if (comprobarColoresCuadros() === "") {
+            if (comprobarColoresCuadros()) {
               guardarColoresEncontrados();
               comprobarEstadoJuego();
               actualizarTituloJuegoTerminado();


### PR DESCRIPTION
Las funciones comprobarColoresCuadros, y ComprobarCuadroElegido hacían return de un string vacío, o un string detallando lo que ocurría, y según el return de las mismas se ejecutaban ciertas funciones en modo-facil, o en modo-intermedio. Ahora se simplificó esto para que directamente el return sea una comparative que tenga que devolver true, o false.