### PR TITLE
Arregla y simplifica comprobarColoresEncontrados

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,19 +219,33 @@ function guardarColoresEncontrados() {
 function comprobarColoresEncontrados(e) {
   let colorCuadro = "";
 
-  coloresDificultadFacil.forEach(function (color) {
-    if (e.target.classList.contains(color)) {
-      colorCuadro = color;
+  if(dificultadElegida === "facil"){
+    coloresDificultadFacil.forEach(function (color) {
+      if (e.target.classList.contains(color)) {
+        colorCuadro = color;
+      }
+    });
+  
+    for (let i = 0; i < coloresYaEncontrados.length; i++) {
+      if (coloresYaEncontrados[i] === colorCuadro) {
+        return true;
+      }
     }
-  });
-
-  for (let i = 0; i < coloresYaEncontrados.length; i++) {
-    if (coloresYaEncontrados[i] === colorCuadro) {
-      return "Este color ya fue encontrado";
+  } else if(dificultadElegida === "intermedio"){
+    coloresDificultadIntermedio.forEach(function (color) {
+      if (e.target.classList.contains(color)) {
+        colorCuadro = color;
+      }
+    });
+  
+    for (let i = 0; i < coloresYaEncontrados.length; i++) {
+      if (coloresYaEncontrados[i] === colorCuadro) {
+        return true;
+      }
     }
   }
 
-  return "";
+  return false;
 }
 
 function comprobarEstadoJuego() {

--- a/modo-facil.js
+++ b/modo-facil.js
@@ -23,7 +23,7 @@ function gestionarModoFacil() {
 $cuadrosGrillaFacil.forEach(function (cuadro) {
   cuadro.addEventListener("click", (e) => {
     if (juegoComenzado && cuadrosElegidos.length < 2) {
-      if (comprobarColoresEncontrados(e) === "") {
+      if (!comprobarColoresEncontrados(e)) {
         if (indicadorTurnos === 1) {
           indicadorTurnos++;
           guardarCuadroElegido(e);

--- a/modo-intermedio.js
+++ b/modo-intermedio.js
@@ -25,7 +25,7 @@ function gestionarModoIntermedio() {
 $cuadrosGrillaIntermedio.forEach(function (cuadro) {
   cuadro.addEventListener("click", (e) => {
     if (juegoComenzado && cuadrosElegidos.length < 2) {
-      if (comprobarColoresEncontrados(e) === "") {
+      if (!comprobarColoresEncontrados(e)) {
         if (indicadorTurnos === 1) {
           indicadorTurnos++;
           guardarCuadroElegido(e);


### PR DESCRIPTION
Esta función fue creada cuando solo existía la dificultad fácil, y se olvidó de actualizar para que también se pueda llamar y funcione correctamente desde modo-intermedio con dicha dificultad. Ya se puede usar con ambas dificultades, y ahora en vez de hacer return de un string vacío hace return false, y en vez de un string detallando que el color no se encontró retorna en true.