### PR TITLE
Agrega un setTimeout para simplificar la función

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,9 +175,12 @@ function mostrarCuadroElegido(e) {
 }
 
 function ocultarCuadrosElegidos() {
-  for (let i = 0; i < cuadrosElegidos.length; i++) {
-    cuadrosElegidos[i].id = "color-oculto";
-  }
+  setTimeout(function (){
+    for (let i = 0; i < cuadrosElegidos.length; i++) {
+      cuadrosElegidos[i].id = "color-oculto";
+    }
+    cuadrosElegidos = [];
+  }, 0850)
 }
 
 function ocultarTodosLosCuadros() {

--- a/modo-facil.js
+++ b/modo-facil.js
@@ -41,11 +41,7 @@ $cuadrosGrillaFacil.forEach(function (cuadro) {
               indicadorTurnos = 1;
             } else {
               indicadorTurnos = 1;
-
-              setTimeout(function () {
-                ocultarCuadrosElegidos();
-                cuadrosElegidos = [];
-              }, 0850);
+              ocultarCuadrosElegidos();
             }
           } else {
             return false;

--- a/modo-intermedio.js
+++ b/modo-intermedio.js
@@ -43,11 +43,7 @@ $cuadrosGrillaIntermedio.forEach(function (cuadro) {
               indicadorTurnos = 1;
             } else {
               indicadorTurnos = 1;
-
-              setTimeout(function () {
-                ocultarCuadrosElegidos();
-                cuadrosElegidos = [];
-              }, 0850);
+              ocultarCuadrosElegidos();
             }
           } else {
             return false;


### PR DESCRIPTION
Antes se llamaba a ocultarCuadrosElegidos mediante un setTimeout, ahora directamente se llama a esta función, y el setTimeout pasa a estar dentro de la misma, para que el código sea más claro